### PR TITLE
add ARM testing via QEMU and image_build mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,12 +165,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.test
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.meta.outputs.image }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/test:latest
           cache-to: type=inline
@@ -188,6 +195,39 @@ jobs:
 
       - name: Re-run playbook (idempotence)
         run: ./test.sh rerun
+
+      - name: Clean
+        if: always()
+        run: ./test.sh clean
+
+  test-playbook-arm:
+    needs: build-test-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/arm64
+          - platform: linux/arm/v7
+          - platform: linux/arm/v6
+            experimental: true
+    continue-on-error: ${{ matrix.experimental == true }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Run playbook test (${{ matrix.platform }})
+        run: ./test.sh
+        env:
+          REMOTE_IMAGE: ${{ needs.build-test-image.outputs.image }}
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Re-run playbook (idempotence)
+        run: ./test.sh rerun
+        env:
+          PLATFORM: ${{ matrix.platform }}
 
       - name: Clean
         if: always()

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -16,6 +16,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN useradd --system --home /var/run/pulse --shell /usr/sbin/nologin pulse && \
     useradd --system --home /var/lib/mpd --shell /usr/sbin/nologin --gid audio mpd
 
+# Stubs to prevent postinst scripts from starting services during build
+RUN for f in /usr/sbin/invoke-rc.d /usr/bin/deb-systemd-invoke /usr/bin/deb-systemd-helper; do \
+        printf '#!/bin/sh\nexit 0\n' > "$f" && chmod +x "$f"; \
+    done && \
+    printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
+
 # Pre-install heavy core packages to speed up test runs
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pulseaudio \
@@ -39,6 +45,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
+# Remove stubs now that all packages are installed
+RUN rm -f /usr/sbin/invoke-rc.d /usr/bin/deb-systemd-invoke /usr/bin/deb-systemd-helper /usr/sbin/policy-rc.d
+
 # Systemd in container: remove unnecessary units
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /etc/systemd/system/*.wants/* \
@@ -60,4 +69,3 @@ WORKDIR /opt/odios/ansible
 VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]
-

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,6 +12,16 @@ FROM base-${TARGETARCH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Pre-create system users so post-install scripts don't fail during build
+RUN useradd --system --home /var/run/pulse --shell /usr/sbin/nologin pulse && \
+    useradd --system --home /var/lib/mpd --shell /usr/sbin/nologin --gid audio mpd
+
+# Pre-install heavy core packages to speed up test runs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pulseaudio \
+    mpd \
+    && rm -rf /var/lib/apt/lists/*
+
 # Bare minimum: systemd to run the container
 RUN apt-get update && apt-get install -y --no-install-recommends \
     systemd \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,14 @@
-FROM debian:trixie
+# Select base image per target architecture:
+#   amd64  → debian:trixie          (CI / local x86 tests)
+#   arm64  → vascoguita/raspios:arm64  (Pi 3/4/5 64-bit)
+#   arm    → vascoguita/raspios:armhf  (Pi armv6/armv7, same image)
+FROM debian:trixie AS base-amd64
+FROM vascoguita/raspios:arm64 AS base-arm64
+FROM vascoguita/raspios:armhf AS base-arm
+
+# hadolint ignore=DL3006
+ARG TARGETARCH=amd64
+FROM base-${TARGETARCH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,37 @@ See [installer/README.md](installer/README.md) for full installation options, en
 | [MALP](https://gitlab.com/gateship-one/malp) | MPD | Android |
 | [BubbleUPnP](https://bubblesoft.org/bubbleupnp/) | UPnP/DLNA | Android / iOS |
 
+
+## odio vs Volumio
+
+|  | **odio** | **Volumio** |
+|---|---|---|
+| **License** | 100% open source | Partially closed source |
+| **Price** | Free | Freemium — Premium at €60/year |
+| **Account required** | No | Yes |
+| **Cloud dependency** | None | Yes (account, Premium, plugins) |
+| **Minimum hardware** | **Raspberry Pi B+** (armv6l, 2014) | Raspberry Pi 3 |
+| **Music library management** | ❌ Streamer only: use your favorite app | ✅ Built-in library browser |
+| **Bluetooth A2DP** | ✅ Included | 💰 Premium only |
+| **AirPlay** | ✅ Included | ✅ Free plugin |
+| **Spotify Connect** | ✅ Included | ✅ Free plugin |
+| **Qobuz** | ✅ Included (via upmpdcli) | 💰 Premium only |
+| **Tidal / Tidal Connect** | ✅ Included (via upmpdcli) | 💰 Premium only |
+| **UPnP/DLNA** | ✅ Included | ✅ Included |
+| **Multi-room** | ✅ Included (Snapcast) | 💰 Premium only |
+| **CD playback** | ✅ Included with metadata | 💰 Premium only |
+| **Network audio sink** | ✅ PulseAudio/PipeWire TCP | ❌ Not supported |
+| **Home Assistant** | Native integration | Unofficial community plugin |
+| **Voice assistant / AI** | Via Home Assistant | 💰 CORRD (Premium) |
+| **Embedded UI** | Lightweight HTMX/Tailwind | Node.js/React |
+| **Multi-node remote** | Svelte PWA (install from browser, no store) | Native mobile app (iOS/Android) |
+| **Architecture** | User session, PulseAudio/PipeWire, Golang | System session, ALSA, Node.js |
+| **System philosophy** | Linux-native modular stack | Appliance-style distribution |
+| **Debian base** | Trixie (stable) | Bookworm (oldstable) |
+| **Installation** | One command (`curl \| bash`) | Image flash |
+| **Upgrade** | `apt upgrade` | OTA updates / Reflash between major versions |
+| **Long-term stability** | No reinstall between Buster and Trixie | Reflash between major versions |
+
 ## Related projects
 
 - [odio-pwa](https://github.com/b0bbywan/odio-pwa) — Progressive Web App to control multiple odios nodes ([live](https://odio-pwa.vercel.app/))

--- a/installer/README.md
+++ b/installer/README.md
@@ -13,7 +13,7 @@ Ansible-based "curl | bash" installer to set up a complete audio/multimedia syst
 ### Optional (disabled by default)
 - **Shairport Sync** - AirPlay receiver
 - **Snapcast** - Multi-room audio client
-- **UPnP/DLNA** - Renderer for UPnP application control, with optional Qobuz streaming (prompted at install time) and Tidal support (package only — tokens require manual configuration post-install in `/etc/upmpdcli.conf`).
+- **UPnP/DLNA** - Renderer for UPnP application control, with optional Qobuz streaming (prompted at install time) and Tidal support (package only — tokens require manual configuration post-install in `/etc/upmpdcli.conf`.
 - **MPD DiscPlayer** - CD/USB support for MPD
 
 ## Fresh install vs existing system
@@ -47,10 +47,11 @@ This applies to: `/etc/bluetooth/main.conf`, `/etc/shairport-sync.conf`, `/etc/d
 
 ## Requirements
 
-- OS: Debian 11+, Ubuntu 22.04+, or Raspberry Pi OS (Bullseye+)
+- OS: Debian 13, Ubuntu 22.04+, or Raspberry Pi OS (Trixie)
 - Architecture: ARM (armv6l, armv7l, aarch64) or x86_64
 - Python 3.10+
 - `python3-cryptography` (present by default on Debian/Ubuntu)
+- `python3-jinja`
 - `curl`
 - Sudo access (or root)
 - Internet connection

--- a/installer/ansible/group_vars/all/main.yml
+++ b/installer/ansible/group_vars/all/main.yml
@@ -1,5 +1,6 @@
 ---
 # Variables par défaut
+install_mode: "live"  # live | image
 target_hostname: "{{ ansible_hostname }}"
 target_user: "{{ ansible_user_id }}"
 spotifyd_version: "0.4.2"

--- a/installer/ansible/playbook.yml
+++ b/installer/ansible/playbook.yml
@@ -6,6 +6,11 @@
     - group_vars/all.yml
 
   pre_tasks:
+    - name: Ensure install_mode is valid
+      ansible.builtin.fail:
+        msg: "install_mode must be 'live' or 'image', got: '{{ install_mode }}'"
+      when: install_mode not in ["live", "image"]
+
     - name: Ensure target user is not root
       ansible.builtin.fail:
         msg: "target_user must not be root"
@@ -16,6 +21,7 @@
         name: dbus.service
         state: started
       become: true
+      when: install_mode == "live"
 
     - name: Set hostname
       ansible.builtin.hostname:

--- a/installer/ansible/playbook.yml
+++ b/installer/ansible/playbook.yml
@@ -72,7 +72,7 @@
     - role: upmpdcli
       when: install_upmpdcli | bool
     - role: spotifyd
-      when: install_spotifyd | bool
+      when: install_spotifyd | bool and ansible_architecture != "armv6l"
 
   post_tasks:
     - name: Display installation summary

--- a/installer/ansible/roles/bluetooth/handlers/main.yml
+++ b/installer/ansible/roles/bluetooth/handlers/main.yml
@@ -4,3 +4,4 @@
     name: bluetooth.service
     state: restarted
   become: true
+  when: install_mode == "live"

--- a/installer/ansible/roles/bluetooth/tasks/main.yml
+++ b/installer/ansible/roles/bluetooth/tasks/main.yml
@@ -44,5 +44,11 @@
   ansible.builtin.systemd:
     name: bluetooth.service
     enabled: true
+  become: true
+
+- name: Start Bluetooth service
+  ansible.builtin.systemd:
+    name: bluetooth.service
     state: started
   become: true
+  when: install_mode == "live"

--- a/installer/ansible/roles/common/tasks/main.yml
+++ b/installer/ansible/roles/common/tasks/main.yml
@@ -34,12 +34,38 @@
     path: "/var/lib/systemd/linger/{{ target_user }}"
   register: common_linger_stat
 
-- name: Enable user session persistence (linger)
+- name: Enable user session persistence (linger) - live
   ansible.builtin.command:
     cmd: "loginctl enable-linger {{ target_user }}"
   become: true
   changed_when: true
-  when: not common_linger_stat.stat.exists
+  when:
+    - not common_linger_stat.stat.exists
+    - install_mode == "live"
+
+- name: Ensure linger directory exists - image build
+  ansible.builtin.file:
+    path: /var/lib/systemd/linger
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  when:
+    - not common_linger_stat.stat.exists
+    - install_mode == "image"
+
+- name: Enable user session persistence (linger) - image build
+  ansible.builtin.file:
+    path: "/var/lib/systemd/linger/{{ target_user }}"
+    state: touch
+    mode: '0644'
+    modification_time: preserve
+    access_time: preserve
+  become: true
+  when:
+    - not common_linger_stat.stat.exists
+    - install_mode == "image"
 
 - name: Check odio gpg file
   ansible.builtin.stat:

--- a/installer/ansible/roles/mpd/handlers/main.yml
+++ b/installer/ansible/roles/mpd/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/mpd/tasks/main.yml
+++ b/installer/ansible/roles/mpd/tasks/main.yml
@@ -9,18 +9,12 @@
   become: true
 
 - name: Disable system MPD service
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    enabled: false
-    state: stopped
+  ansible.builtin.include_tasks: "../../../tasks/systemd_disable_system.yml"
+  vars:
+    service_name: "{{ item }}"
   loop:
     - mpd.service
     - mpd.socket
-  become: true
-  register: mpd_disable
-  failed_when:
-    - mpd_disable.failed | bool
-    - '"Could not find" not in (mpd_disable.msg | default(""))'
 
 - name: Create MPD config directory
   ansible.builtin.file:
@@ -145,12 +139,6 @@
   become: true
 
 - name: Enable user MPD service
-  ansible.builtin.systemd:
-    name: mpd.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: mpd.service

--- a/installer/ansible/roles/mpd_discplayer/handlers/main.yml
+++ b/installer/ansible/roles/mpd_discplayer/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/mpd_discplayer/tasks/main.yml
+++ b/installer/ansible/roles/mpd_discplayer/tasks/main.yml
@@ -121,12 +121,6 @@
   notify: Restart mpd-discplayer
 
 - name: Enable mpd-discplayer service
-  ansible.builtin.systemd:
-    name: mpd-discplayer.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: mpd-discplayer.service

--- a/installer/ansible/roles/odio_api/handlers/main.yml
+++ b/installer/ansible/roles/odio_api/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/odio_api/tasks/main.yml
+++ b/installer/ansible/roles/odio_api/tasks/main.yml
@@ -27,12 +27,6 @@
   notify: Restart odio-api
 
 - name: Enable odio-api service
-  ansible.builtin.systemd:
-    name: odio-api.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: odio-api.service

--- a/installer/ansible/roles/odio_api/templates/config.yaml.j2
+++ b/installer/ansible/roles/odio_api/templates/config.yaml.j2
@@ -20,9 +20,6 @@ systemd:
   {% if install_bluetooth %}
     - bluetooth.service
   {% endif %}
-  {% if install_upmpdcli %}
-    - upmpdcli.service
-  {% endif %}
   user:
   {% if install_pulseaudio %}
     - pulseaudio.service
@@ -41,6 +38,9 @@ systemd:
   {% endif %}
   {% if install_spotifyd %}
     - spotifyd.service
+  {% endif %}
+  {% if install_upmpdcli %}
+    - upmpdcli.service
   {% endif %}
 
 # Features

--- a/installer/ansible/roles/pipewire/handlers/main.yml
+++ b/installer/ansible/roles/pipewire/handlers/main.yml
@@ -12,3 +12,4 @@
     - wireplumber.service
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/pulseaudio/handlers/main.yml
+++ b/installer/ansible/roles/pulseaudio/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/pulseaudio/tasks/main.yml
+++ b/installer/ansible/roles/pulseaudio/tasks/main.yml
@@ -47,30 +47,18 @@
     - wireplumber.service
 
 - name: Mask existing PipeWire units for target user
-  ansible.builtin.systemd:
-    name: "{{ item.item }}"
-    masked: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_mask_user.yml"
+  vars:
+    service_name: "{{ item.item }}"
   loop: "{{ pulseaudio_pw_units.results }}"
   when:
     - "'install ok installed' in pulseaudio_pw_status.stdout"
     - item.stat.exists
-  become: true
-  become_user: "{{ target_user }}"
 
 - name: Enable user PulseAudio services
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: "{{ item }}"
   loop:
     - pulseaudio.service
     - pulse-tcp.service
-  become: true
-  become_user: "{{ target_user }}"

--- a/installer/ansible/roles/shairport_sync/handlers/main.yml
+++ b/installer/ansible/roles/shairport_sync/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/shairport_sync/tasks/main.yml
+++ b/installer/ansible/roles/shairport_sync/tasks/main.yml
@@ -88,23 +88,11 @@
   become: true
 
 - name: Disable system shairport-sync service
-  ansible.builtin.systemd:
-    name: shairport-sync.service
-    enabled: false
-    state: stopped
-  become: true
-  register: shairport_sync_disable
-  failed_when:
-    - shairport_sync_disable.failed | bool
-    - '"Could not find" not in (shairport_sync_disable.msg | default(""))'
+  ansible.builtin.include_tasks: "../../../tasks/systemd_disable_system.yml"
+  vars:
+    service_name: shairport-sync.service
 
 - name: Enable user shairport-sync service
-  ansible.builtin.systemd:
-    name: shairport-sync.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: shairport-sync.service

--- a/installer/ansible/roles/snapclient/handlers/main.yml
+++ b/installer/ansible/roles/snapclient/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/snapclient/tasks/main.yml
+++ b/installer/ansible/roles/snapclient/tasks/main.yml
@@ -27,15 +27,9 @@
     conf_path: /etc/default/snapclient
 
 - name: Disable system snapclient service
-  ansible.builtin.systemd:
-    name: snapclient.service
-    enabled: false
-    state: stopped
-  become: true
-  register: snapclient_disable
-  failed_when:
-    - snapclient_disable.failed | bool
-    - '"Could not find" not in (snapclient_disable.msg | default(""))'
+  ansible.builtin.include_tasks: "../../../tasks/systemd_disable_system.yml"
+  vars:
+    service_name: snapclient.service
 
 - name: Copy user snapclient service
   ansible.builtin.copy:
@@ -47,12 +41,6 @@
   become: true
 
 - name: Enable user snapclient service
-  ansible.builtin.systemd:
-    name: snapclient.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: snapclient.service

--- a/installer/ansible/roles/spotifyd/handlers/main.yml
+++ b/installer/ansible/roles/spotifyd/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/spotifyd/tasks/main.yml
+++ b/installer/ansible/roles/spotifyd/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Fail on unsupported architecture (armv6l)
-  ansible.builtin.fail:
-    msg: "spotifyd does not provide armv6l builds since v0.4.x"
-  when: ansible_architecture == "armv6l"
-
 - name: Check installed spotifyd version
   ansible.builtin.command: /usr/local/bin/spotifyd --version
   register: spotifyd_current_version
@@ -52,12 +47,6 @@
   notify: Restart spotifyd
 
 - name: Enable user spotifyd service
-  ansible.builtin.systemd:
-    name: spotifyd.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: spotifyd.service

--- a/installer/ansible/roles/upmpdcli/files/upmpdcli.service
+++ b/installer/ansible/roles/upmpdcli/files/upmpdcli.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=UPnP Renderer front-end to MPD
+After=network-online.target mpd.service systemd-remount-fs.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Note: if start fails check with "systemctl status upmpdcli"
+ExecStart=/usr/bin/upmpdcli -c /etc/upmpdcli.conf
+# For some reason, it happens the first start of libupnp fails. Probably
+# this should be started later in the start sequence, but I don't know
+# how. Retry a bit later.
+Restart=always
+RestartSec=1min
+
+[Install]
+WantedBy=default.target

--- a/installer/ansible/roles/upmpdcli/handlers/main.yml
+++ b/installer/ansible/roles/upmpdcli/handlers/main.yml
@@ -8,3 +8,4 @@
     XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
   become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/upmpdcli/handlers/main.yml
+++ b/installer/ansible/roles/upmpdcli/handlers/main.yml
@@ -3,4 +3,8 @@
   ansible.builtin.systemd:
     name: upmpdcli.service
     state: restarted
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
+  become_user: "{{ target_user }}"

--- a/installer/ansible/roles/upmpdcli/tasks/main.yml
+++ b/installer/ansible/roles/upmpdcli/tasks/main.yml
@@ -87,10 +87,40 @@
   vars:
     conf_path: /etc/upmpdcli.conf
 
-- name: Enable upmpdcli service
+- name: Ensure upmpdcli config is world-readable
+  ansible.builtin.file:
+    path: /etc/upmpdcli.conf
+    mode: '0644'
+    state: file
+  become: true
+
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Disable upmpdcli system service
+  ansible.builtin.systemd:
+    name: upmpdcli.service
+    enabled: false
+    state: stopped
+    daemon_reload: true
+  become: true
+  when: "'upmpdcli.service' in ansible_facts.services"
+
+- name: Deploy upmpdcli user service
+  ansible.builtin.copy:
+    src: upmpdcli.service
+    dest: "/usr/lib/systemd/user/upmpdcli.service"
+    mode: '0644'
+  become: true
+  notify: Restart upmpdcli
+
+- name: Enable user upmpdcli user service
   ansible.builtin.systemd:
     name: upmpdcli.service
     enabled: true
-    state: started
+    scope: user
     daemon_reload: true
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
   become: true
+  become_user: "{{ target_user }}"

--- a/installer/ansible/roles/upmpdcli/tasks/main.yml
+++ b/installer/ansible/roles/upmpdcli/tasks/main.yml
@@ -94,17 +94,10 @@
     state: file
   become: true
 
-- name: Gather service facts
-  ansible.builtin.service_facts:
-
 - name: Disable upmpdcli system service
-  ansible.builtin.systemd:
-    name: upmpdcli.service
-    enabled: false
-    state: stopped
-    daemon_reload: true
-  become: true
-  when: "'upmpdcli.service' in ansible_facts.services"
+  ansible.builtin.include_tasks: "../../../tasks/systemd_disable_system.yml"
+  vars:
+    service_name: upmpdcli.service
 
 - name: Deploy upmpdcli user service
   ansible.builtin.copy:
@@ -114,13 +107,7 @@
   become: true
   notify: Restart upmpdcli
 
-- name: Enable user upmpdcli user service
-  ansible.builtin.systemd:
-    name: upmpdcli.service
-    enabled: true
-    scope: user
-    daemon_reload: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
-  become: true
-  become_user: "{{ target_user }}"
+- name: Enable user upmpdcli service
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: upmpdcli.service

--- a/installer/ansible/tasks/systemd_disable_system.yml
+++ b/installer/ansible/tasks/systemd_disable_system.yml
@@ -1,0 +1,24 @@
+---
+# Disable and stop a system service.
+# enabled: false runs in all modes (filesystem-only, removes wants symlink).
+# state: stopped only runs in live mode (requires running systemd).
+# Ignores "Could not find" errors (service may not be installed).
+# Variables:
+#   service_name: name of the service (e.g. mpd.service)
+
+- name: Disable system service
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    enabled: false
+  become: true
+
+- name: Stop system service
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    state: stopped
+  become: true
+  register: _disable_result
+  failed_when:
+    - _disable_result.failed | bool
+    - '"Could not find" not in (_disable_result.msg | default(""))'
+  when: install_mode == "live"

--- a/installer/ansible/tasks/systemd_enable_user.yml
+++ b/installer/ansible/tasks/systemd_enable_user.yml
@@ -1,0 +1,25 @@
+---
+# Enable a systemd user service.
+# In image_build mode, uses global scope (no user session needed).
+# Variables:
+#   service_name: name of the service (e.g. pulseaudio.service)
+
+- name: Enable user service - live
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    enabled: true
+    scope: user
+    daemon_reload: true
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+  become: true
+  become_user: "{{ target_user }}"
+  when: install_mode == "live"
+
+- name: Enable user service - image build
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    enabled: true
+    scope: global
+  become: true
+  when: install_mode == "image"

--- a/installer/ansible/tasks/systemd_mask_user.yml
+++ b/installer/ansible/tasks/systemd_mask_user.yml
@@ -1,0 +1,25 @@
+---
+# Mask a systemd user service.
+# In image_build mode, uses global scope (no user session needed).
+# Variables:
+#   service_name: name of the service (e.g. pipewire.service)
+
+- name: Mask user service - live
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    masked: true
+    scope: user
+    daemon_reload: true
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+  become: true
+  become_user: "{{ target_user }}"
+  when: install_mode == "live"
+
+- name: Mask user service - image build
+  ansible.builtin.systemd:
+    name: "{{ service_name }}"
+    masked: true
+    scope: global
+  become: true
+  when: install_mode == "image"

--- a/test.sh
+++ b/test.sh
@@ -5,19 +5,28 @@ CONTAINER_NAME="odios-test"
 GITHUB_REPO="b0bbywan/odios"
 _DEFAULT_TAG="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo latest)"
 REMOTE_IMAGE="${REMOTE_IMAGE:-ghcr.io/${GITHUB_REPO}/test:${_DEFAULT_TAG}}"
+PLATFORM="${PLATFORM:-}"  # e.g. linux/arm64, linux/arm/v7, linux/arm/v6
 BUILD_LOCAL=false
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
+platform_flags() {
+    [[ -n "${PLATFORM}" ]] && echo "--platform ${PLATFORM}" || true
+}
+
 resolve_image() {
+    local pflags; pflags=$(platform_flags)
     if [[ "${BUILD_LOCAL}" == "true" ]]; then
         echo "=== Building image locally ==="
-        docker build -t "${REMOTE_IMAGE}" -f Dockerfile.test .
+        # shellcheck disable=SC2086
+        docker build ${pflags} -t "${REMOTE_IMAGE}" -f Dockerfile.test .
     else
         echo "=== Pulling image ==="
-        docker pull "${REMOTE_IMAGE}" || {
+        # shellcheck disable=SC2086
+        docker pull ${pflags} "${REMOTE_IMAGE}" || {
             echo "Pull failed, falling back to local build..."
-            docker build -t "${REMOTE_IMAGE}" -f Dockerfile.test .
+            # shellcheck disable=SC2086
+            docker build ${pflags} -t "${REMOTE_IMAGE}" -f Dockerfile.test .
         }
     fi
 }
@@ -25,14 +34,17 @@ resolve_image() {
 start_container() {
     resolve_image
 
-    echo "=== Starting container with systemd ==="
+    local pflags; pflags=$(platform_flags)
+    echo "=== Starting container with systemd${PLATFORM:+ ($PLATFORM)} ==="
     docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+    # shellcheck disable=SC2086
     docker run -d \
       --name "${CONTAINER_NAME}" \
       --privileged \
       --cgroupns=host \
       --user root \
       -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+      ${pflags} \
       "${REMOTE_IMAGE}"
 
     echo "=== Waiting for systemd ==="
@@ -81,6 +93,9 @@ while [[ "${1:-}" == --* ]]; do
         echo ""
         echo "  --build            - Force local image build instead of pulling from GHCR"
         echo ""
+        echo "  Env vars:"
+        echo "    PLATFORM           - Docker platform (e.g. linux/arm64, linux/arm/v7, linux/arm/v6)"
+        echo ""
         echo "  test               - Pull/build + start + run playbook directly (default)"
         echo "  shell              - Shell into running container"
         echo "  rerun              - Re-run playbook without restart"
@@ -110,15 +125,29 @@ install_ansible() {
       pip3 install --break-system-packages --quiet "ansible-core==2.19.*"
 }
 
+# Under QEMU user-mode, sudo setuid is not honoured — run ansible as root.
+# On native x86 we keep -u odios to also exercise the sudo escalation path.
+# When running as root, target_user must be passed explicitly (defaults to
+# ansible_user_id which would be root, blocked by the playbook guard).
+ansible_exec_user() {
+    [[ -z "${PLATFORM}" ]] && echo "-u odios" || true
+}
+
+ansible_extra_flags() {
+    [[ -n "${PLATFORM}" ]] && echo "-e target_user=odios -e install_mode=image" || true
+}
+
 case "${ACTION}" in
   test)
     start_container
     install_ansible
 
     echo "=== Running playbook ==="
-    docker exec -u odios "${CONTAINER_NAME}" \
+    # shellcheck disable=SC2046
+    docker exec $(ansible_exec_user) "${CONTAINER_NAME}" \
       ansible-playbook -v -i inventory/localhost.yml \
         /opt/odios/ansible/playbook.yml \
+        $(ansible_extra_flags) \
         -e "install_shairport_sync=true" \
         -e "install_upmpdcli=true" \
         -e "install_tidal=true" \
@@ -134,13 +163,16 @@ case "${ACTION}" in
     ;;
 
   shell)
-    docker exec -it -u odios "${CONTAINER_NAME}" bash
+    # shellcheck disable=SC2046
+    docker exec -it $(ansible_exec_user) "${CONTAINER_NAME}" bash
     ;;
 
   rerun)
     echo "=== Re-running playbook ==="
-    docker exec -u odios "${CONTAINER_NAME}" \
+    # shellcheck disable=SC2046
+    docker exec $(ansible_exec_user) "${CONTAINER_NAME}" \
       ansible-playbook -i inventory/localhost.yml /opt/odios/ansible/playbook.yml \
+        $(ansible_extra_flags) \
         -e "install_shairport_sync=true" \
         -e "install_upmpdcli=true" \
         -e "install_tidal=true" \


### PR DESCRIPTION
- Dockerfile.test: multi-arch base (debian:trixie for amd64, vascoguita/raspios for arm64/armhf)
- release.yml: build multi-arch test image, add test-playbook-arm matrix job (arm64/armv7 blocking, armv6 non-blocking)
- test.sh: PLATFORM env var support, ansible runs as root under QEMU with install_mode=image to bypass sudo/dbus limitations
- Add install_mode enum (live|image) replacing boolean image_build: handlers skip restarts, systemd enables use global scope, linger uses file touch instead of loginctl
- Add shared tasks systemd_enable_user.yml and systemd_disable_system.yml to centralize install_mode logic