### PR TITLE
mpDris2: add systemd override for auto-restart and mpd dependency

### DIFF
--- a/installer/ansible/roles/mpd/files/mpDris2-override.conf
+++ b/installer/ansible/roles/mpd/files/mpDris2-override.conf
@@ -1,0 +1,7 @@
+[Unit]
+After=mpd.service
+Requires=mpd.service
+
+[Service]
+Restart=always
+RestartSec=5

--- a/installer/ansible/roles/mpd/tasks/main.yml
+++ b/installer/ansible/roles/mpd/tasks/main.yml
@@ -166,6 +166,25 @@
     mode: '0775'
   become: true
 
+- name: Create mpDris2 systemd override directory
+  ansible.builtin.file:
+    path: "/usr/lib/systemd/user/mpDris2.service.d"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+- name: Deploy mpDris2 systemd override
+  ansible.builtin.copy:
+    src: mpDris2-override.conf
+    dest: "/usr/lib/systemd/user/mpDris2.service.d/override.conf"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Restart mpd
+
 - name: Enable user MPD service
   ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
   vars:

--- a/installer/ansible/tasks/systemd_enable_system.yml
+++ b/installer/ansible/tasks/systemd_enable_system.yml
@@ -10,10 +10,3 @@
     name: "{{ service_name }}"
     enabled: true
   become: true
-
-- name: Start system service
-  ansible.builtin.systemd:
-    name: "{{ service_name }}"
-    state: started
-  become: true
-  when: install_mode == "live"


### PR DESCRIPTION
Ensures mpDris2 starts after mpd.service, requires it, and always restarts (with 5s delay) instead of only on failure.