### PR TITLE
mpd: replace distro mpdris2 with b0bbywan/mpDris2 fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Most service run as **systemd user services** — no root daemons, full per-user
 | [go-mpd-discplayer](https://github.com/b0bbywan/go-mpd-discplayer) | Automatic CD/USB playback with metadata via MPD | user |
 | PulseAudio | Central audio server, routes all sources to the DAC output — other PCs running PulseAudio or PipeWire can stream to it over the network via TCP/Zeroconf | user |
 | MPD | Music Player Daemon (network, CD/USB) | user |
+| [mpDris2](https://github.com/b0bbywan/mpDris2) (fork) | MPRIS bridge for MPD with CD cover art support | user |
 | Shairport Sync | AirPlay receiver | user |
 | Snapcast | Multi-room audio client | user |
 | upmpdcli | UPnP/DLNA renderer | system |

--- a/installer/ansible/roles/common/tasks/main.yml
+++ b/installer/ansible/roles/common/tasks/main.yml
@@ -97,3 +97,6 @@
     owner: root
     group: root
   become: true
+
+- name: Setup polkit
+  ansible.builtin.include_tasks: polkit.yml

--- a/installer/ansible/roles/common/tasks/polkit.yml
+++ b/installer/ansible/roles/common/tasks/polkit.yml
@@ -1,0 +1,17 @@
+---
+- name: Install polkit
+  ansible.builtin.apt:
+    name: polkitd
+    state: present
+    update_cache: true
+    install_recommends: false
+  become: true
+
+- name: Ensure polkit rules directory exists
+  ansible.builtin.file:
+    path: /etc/polkit-1/rules.d
+    state: directory
+    owner: root
+    group: polkitd
+    mode: '0750'
+  become: true

--- a/installer/ansible/roles/mpd/defaults/main.yml
+++ b/installer/ansible/roles/mpd/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mpd_mpdris2_version: "0.9.2"

--- a/installer/ansible/roles/mpd/files/mpDris2-override.conf
+++ b/installer/ansible/roles/mpd/files/mpDris2-override.conf
@@ -1,7 +1,0 @@
-[Unit]
-After=mpd.service
-Requires=mpd.service
-
-[Service]
-Restart=always
-RestartSec=5

--- a/installer/ansible/roles/mpd/handlers/main.yml
+++ b/installer/ansible/roles/mpd/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Restart mpd
   ansible.builtin.systemd:
-    name: "{{ item }}.service"
+    name: mpd.service
     state: restarted
     scope: user
   environment:
@@ -9,6 +9,21 @@
   become: true
   become_user: "{{ target_user }}"
   when: install_mode == "live"
-  loop:
-    - mpd
-    - mpDris2
+
+- name: Reload dbus
+  ansible.builtin.systemd:
+    name: dbus.service
+    state: reloaded
+  become: true
+  when: ansible_facts.services['dbus.service'] is defined
+
+- name: Restart mpDris2
+  ansible.builtin.systemd:
+    name: mpDris2.service
+    state: restarted
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+  become: true
+  become_user: "{{ target_user }}"
+  when: install_mode == "live"

--- a/installer/ansible/roles/mpd/tasks/main.yml
+++ b/installer/ansible/roles/mpd/tasks/main.yml
@@ -4,11 +4,12 @@
     name:
       - mpd
       - mpc
-      - mpdris2
-      - python3-mutagen
     state: present
     install_recommends: false
   become: true
+
+- name: Install mpDris2 fork
+  ansible.builtin.include_tasks: mpdris2.yml
 
 - name: Disable system MPD service
   ansible.builtin.include_tasks: "../../../tasks/systemd_disable_system.yml"
@@ -20,20 +21,8 @@
 
 - name: Create MPD config directory
   ansible.builtin.file:
-    path: "/home/{{ target_user }}/.config/{{ item }}"
+    path: "/home/{{ target_user }}/.config/mpd"
     state: directory
-    owner: "{{ target_user }}"
-    group: "{{ target_user }}"
-    mode: '0700'
-  become: true
-  loop:
-    - mpDris2
-    - mpd
-
-- name: Create mpDris2 config file
-  ansible.builtin.template:
-    src: mpDris2.conf.j2
-    dest: "/home/{{ target_user }}/.config/mpDris2/mpDris2.conf"
     owner: "{{ target_user }}"
     group: "{{ target_user }}"
     mode: '0700'
@@ -166,29 +155,13 @@
     mode: '0775'
   become: true
 
-- name: Create mpDris2 systemd override directory
+- name: Remove legacy mpDris2 systemd override directory
   ansible.builtin.file:
     path: "/usr/lib/systemd/user/mpDris2.service.d"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
+    state: absent
   become: true
-
-- name: Deploy mpDris2 systemd override
-  ansible.builtin.copy:
-    src: mpDris2-override.conf
-    dest: "/usr/lib/systemd/user/mpDris2.service.d/override.conf"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  notify: Restart mpd
 
 - name: Enable user MPD service
   ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
   vars:
-    service_name: "{{ item }}.service"
-  loop:
-    - mpd
-    - mpDris2
+    service_name: mpd.service

--- a/installer/ansible/roles/mpd/tasks/mpdris2.yml
+++ b/installer/ansible/roles/mpd/tasks/mpdris2.yml
@@ -1,0 +1,87 @@
+---
+- name: Remove mpdris2 distro package if present
+  ansible.builtin.apt:
+    name: mpdris2
+    state: absent
+  become: true
+
+- name: Install mpDris2 dependencies
+  ansible.builtin.apt:
+    name:
+      - python3-gi
+      - python3-mpd
+      - python3-dbus
+      - python3-mutagen
+    state: present
+    install_recommends: false
+  become: true
+
+- name: Create mpDris2 download directory
+  ansible.builtin.file:
+    path: "/tmp/mpDris2-{{ mpd_mpdris2_version }}"
+    state: directory
+    mode: '0755'
+
+- name: Download mpDris2 fork release
+  ansible.builtin.unarchive:
+    src: "https://github.com/b0bbywan/mpDris2/releases/download/v{{ mpd_mpdris2_version }}/mpDris2-{{ mpd_mpdris2_version }}.tar.gz"
+    dest: "/tmp/mpDris2-{{ mpd_mpdris2_version }}"
+    remote_src: true
+    creates: "/tmp/mpDris2-{{ mpd_mpdris2_version }}/mpDris2"
+
+- name: Install mpDris2 binary
+  ansible.builtin.copy:
+    src: "/tmp/mpDris2-{{ mpd_mpdris2_version }}/mpDris2"
+    dest: /usr/local/bin/mpDris2
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  notify: Restart mpDris2
+
+- name: Install mpDris2 systemd user service
+  ansible.builtin.copy:
+    src: "/tmp/mpDris2-{{ mpd_mpdris2_version }}/mpDris2.service"
+    dest: /usr/lib/systemd/user/mpDris2.service
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Restart mpDris2
+
+- name: Install mpDris2 D-Bus service
+  ansible.builtin.copy:
+    src: "/tmp/mpDris2-{{ mpd_mpdris2_version }}/org.mpris.MediaPlayer2.mpd.service"
+    dest: /usr/share/dbus-1/services/org.mpris.MediaPlayer2.mpd.service
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Reload dbus
+
+- name: Create mpDris2 config directory
+  ansible.builtin.file:
+    path: "/home/{{ target_user }}/.config/mpDris2"
+    state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0700'
+  become: true
+
+- name: Create mpDris2 config file
+  ansible.builtin.template:
+    src: mpDris2.conf.j2
+    dest: "/home/{{ target_user }}/.config/mpDris2/mpDris2.conf"
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: '0700'
+  become: true
+  notify: Restart mpDris2
+
+- name: Enable user mpDris2 service
+  ansible.builtin.include_tasks: "../../../tasks/systemd_enable_user.yml"
+  vars:
+    service_name: mpDris2.service

--- a/installer/ansible/roles/mpd_discplayer/tasks/main.yml
+++ b/installer/ansible/roles/mpd_discplayer/tasks/main.yml
@@ -25,16 +25,6 @@
       - cdrom
   become: true
 
-- name: Ensure polkit rules directory exists
-  ansible.builtin.file:
-    path: /etc/polkit-1/rules.d
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  become: true
-  when: is_headless or install_mode == "image"
-
 - name: Deploy udisk polkit rule
   ansible.builtin.template:
     src: mpd-udisks.rules.j2

--- a/installer/ansible/roles/odio_api/tasks/main.yml
+++ b/installer/ansible/roles/odio_api/tasks/main.yml
@@ -3,7 +3,6 @@
   ansible.builtin.apt:
     name: odio-api
     state: present
-    update_cache: true
     install_recommends: false
   become: true
   notify: Restart odio-api
@@ -19,16 +18,6 @@
 
 - name: Check for graphical session
   ansible.builtin.include_tasks: "../../../tasks/check_graphical_session.yml"
-
-- name: Ensure polkit rules directory exists
-  ansible.builtin.file:
-    path: /etc/polkit-1/rules.d
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  become: true
-  when: is_headless or install_mode == "image"
 
 - name: Deploy polkit shutdown rule
   ansible.builtin.template:

--- a/installer/ansible/roles/pipewire/tasks/main.yml
+++ b/installer/ansible/roles/pipewire/tasks/main.yml
@@ -6,7 +6,6 @@
       - pipewire-pulse
       - wireplumber
     state: present
-    update_cache: true
     install_recommends: false
   become: true
   notify: Restart pipewire-pulse

--- a/installer/ansible/roles/pulseaudio/tasks/main.yml
+++ b/installer/ansible/roles/pulseaudio/tasks/main.yml
@@ -5,7 +5,6 @@
       - pulseaudio
       - pulseaudio-module-zeroconf
     state: present
-    update_cache: true
     install_recommends: false
   become: true
   notify: Restart pulseaudio

--- a/installer/ansible/roles/spotifyd/tasks/main.yml
+++ b/installer/ansible/roles/spotifyd/tasks/main.yml
@@ -3,7 +3,6 @@
   ansible.builtin.apt:
     name: spotifyd
     state: present
-    update_cache: false
   become: true
   notify: Restart spotifyd
 


### PR DESCRIPTION
Install mpDris2 from GitHub releases instead of apt to get full cover art support. All mpDris2 tasks (install, config, service, enable) moved to dedicated mpdris2.yml. Remove systemd override incompatible with --no-reconnect flag.