### PR TITLE
branding: make motd opt-in via install_motd var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           else
             SHA="${{ github.event.pull_request.head.sha }}"
-            echo "version=dev-${SHA::8}" >> "$GITHUB_OUTPUT"
+            VERSION=$(git describe --tags --long --always "${SHA}")
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "archive_name=${ARCHIVE_PREFIX}-dev.tar.gz" >> "$GITHUB_OUTPUT"
             echo "is_release=false" >> "$GITHUB_OUTPUT"
           fi

--- a/image-builder/config.sh
+++ b/image-builder/config.sh
@@ -50,6 +50,7 @@ ANSIBLE_EXTRA_VARS=(
     "target_user=${ODIOS_USER}"
     "target_hostname=odio"
     "install_mode=image"
+    "install_motd=true"
     "install_spotifyd=true"
     "install_tidal=true"
     "install_upnpwebradios=true"

--- a/installer/ansible/group_vars/all/main.yml
+++ b/installer/ansible/group_vars/all/main.yml
@@ -23,3 +23,6 @@ install_upmpdcli: true
 install_tidal: false
 install_spotifyd: false
 install_upnpwebradios: false
+
+# Branding (odio-motd, hushlogin, .profile hook)
+install_motd: false

--- a/installer/ansible/roles/branding/files/odio-check-upgrade
+++ b/installer/ansible/roles/branding/files/odio-check-upgrade
@@ -18,7 +18,9 @@ STATE_PATH = os.path.expanduser("~/.cache/odio/state.json")
 OUTPUT_PATH = os.path.expanduser("~/.cache/odio/upgrades.json")
 
 _PRE_PHASES = {"a": 0, "b": 1, "rc": 2}
-_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?$")
+_VERSION_RE = re.compile(
+    r"^(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?(?:-(\d+)-g[0-9a-f]+)?$"
+)
 
 
 def parse_version(v: str) -> tuple:
@@ -32,7 +34,8 @@ def parse_version(v: str) -> tuple:
     else:
         phase = 3
         pre_num = 0
-    return (year, month, patch, phase, pre_num)
+    dev_commits = int(m.group(6)) if m.group(6) else 0
+    return (year, month, patch, phase, pre_num, dev_commits)
 
 
 def fetch_manifest(url: str) -> dict:

--- a/installer/ansible/roles/branding/files/odio-motd
+++ b/installer/ansible/roles/branding/files/odio-motd
@@ -35,6 +35,13 @@ for r in data.get('roles', []):
     [ -n "$upgrade" ] && printf '\n%s\n' "$upgrade"
 fi
 
+OS_NAME="Linux"
+if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    OS_NAME="${NAME:-Linux}"
+fi
+
 echo
-echo "odio comes with ABSOLUTELY NO WARRANTY, to the extent"
-echo "permitted by applicable law."
+echo "odio - ${OS_NAME} comes with ABSOLUTELY NO WARRANTY, to the"
+echo "extent permitted by applicable law."

--- a/installer/ansible/roles/branding/tasks/main.yml
+++ b/installer/ansible/roles/branding/tasks/main.yml
@@ -25,7 +25,7 @@
     group: "{{ target_user }}"
     mode: '0755'
   become: true
-  when: install_mode == "image"
+  when: install_motd | bool
 
 - name: Hook odio-motd into ~/.profile
   ansible.builtin.blockinfile:
@@ -40,7 +40,7 @@
           *i*) [ -x "$HOME/.local/bin/odio-motd" ] && "$HOME/.local/bin/odio-motd" ;;
       esac
   become: true
-  when: install_mode == "image"
+  when: install_motd | bool
 
 - name: Suppress system motd for odio user
   ansible.builtin.file:
@@ -52,7 +52,7 @@
     modification_time: preserve
     access_time: preserve
   become: true
-  when: install_mode == "image"
+  when: install_motd | bool
 
 - name: Deploy odio-check-upgrade systemd units
   ansible.builtin.template:

--- a/installer/ansible/roles/branding/vars/main.yml
+++ b/installer/ansible/roles/branding/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-branding_version: "2026.4.1rc1"
+branding_version: "2026.4.1rc2"

--- a/installer/ansible/tasks/write_state.yml
+++ b/installer/ansible/tasks/write_state.yml
@@ -42,3 +42,10 @@
     group: "{{ target_user }}"
     mode: '0644'
   become: true
+
+- name: Refresh ~/.cache/odio/upgrades.json
+  ansible.builtin.command: "/home/{{ target_user }}/.local/bin/odio-check-upgrade"
+  become: true
+  become_user: "{{ target_user }}"
+  changed_when: false
+  failed_when: false

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -77,6 +77,7 @@ ask_config() {
     read -rp "Install Snapcast client? [Y/n]: "            INSTALL_SNAPCLIENT
     read -rp "Install UPnP/DLNA renderer? [Y/n]: "         INSTALL_UPMPDCLI
     read -rp "Install Spotifyd (Spotify Connect)? [y/N]: " INSTALL_SPOTIFYD
+    read -rp "Install odio-motd branding (login banner, hushlogin)? [y/N]: " INSTALL_MOTD
 
     if [[ "${INSTALL_UPMPDCLI:-Y}" != "n" && "${INSTALL_UPMPDCLI:-Y}" != "N" ]]; then
         echo ""
@@ -120,6 +121,7 @@ prompt_for_config() {
     INSTALL_TIDAL="${INSTALL_TIDAL:-N}"
     INSTALL_SPOTIFYD="${INSTALL_SPOTIFYD:-N}"
     INSTALL_UPNPWEBRADIOS="${INSTALL_UPNPWEBRADIOS:-N}"
+    INSTALL_MOTD="${INSTALL_MOTD:-N}"
     QOBUZ_USER="${QOBUZ_USER:-}"
     QOBUZ_PASS="${QOBUZ_PASS:-}"
 }
@@ -313,7 +315,8 @@ run_playbook() {
   "install_upmpdcli":       $(bool "$INSTALL_UPMPDCLI"),
   "install_tidal":          $(bool "$INSTALL_TIDAL"),
   "install_upnpwebradios":  $(bool "$INSTALL_UPNPWEBRADIOS"),
-  "install_mpd_discplayer": $(bool "$INSTALL_MPD_DISCPLAYER")
+  "install_mpd_discplayer": $(bool "$INSTALL_MPD_DISCPLAYER"),
+  "install_motd":           $(bool "$INSTALL_MOTD")
 }
 EOF
 )


### PR DESCRIPTION
Live installs now prompt for odio-motd (login banner, hushlogin, .profile hook) instead of skipping it silently. Image builds pass install_motd=true explicitly via ANSIBLE_EXTRA_VARS.