### PR TITLE
perf: vendor Mitogen to speed up playbook runs on slow CPUs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ permissions:
 
 env:
   ANSIBLE_CORE_VERSION: '2.19.*'
+  # Vendored for the mitogen_linear strategy — speeds up playbook runs on armhf.
+  MITOGEN_VERSION: '0.3.49'
   ARCHIVE_PREFIX: odio
 
 jobs:
@@ -55,11 +57,13 @@ jobs:
           pip install \
             --target=staging/vendor \
             --no-compile \
-            "ansible-core==${{ env.ANSIBLE_CORE_VERSION }}"
+            "ansible-core==${{ env.ANSIBLE_CORE_VERSION }}" \
+            "mitogen==${{ env.MITOGEN_VERSION }}"
 
           # Collect licenses before stripping dist-info
           mkdir -p staging/licenses
           cp licences/ANSIBLE-LICENSE-GPLv3 staging/licenses/ANSIBLE-LICENSE-GPLv3
+          cp licences/MITOGEN-LICENSE-BSD3 staging/licenses/MITOGEN-LICENSE-BSD3
           cp LICENSE staging/licenses/ODIOS-LICENSE-BSD2
 
           # Remove packages with unavoidable native extensions — provided by the system at install time
@@ -69,6 +73,10 @@ jobs:
           find staging/vendor -name '*.so' -delete
           find staging/vendor -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
           find staging/vendor -type d -name '*.dist-info' -exec rm -rf {} + 2>/dev/null || true
+
+          # Mitogen is pure Python — the strategy plugin must survive the strip
+          test -f staging/vendor/ansible_mitogen/plugins/strategy/mitogen_linear.py \
+            || { echo "::error::mitogen_linear strategy missing from vendor"; exit 1; }
 
           echo "Vendor size: $(du -sh staging/vendor | cut -f1)"
 

--- a/image-builder/lib/provision.sh
+++ b/image-builder/lib/provision.sh
@@ -61,7 +61,10 @@ mkdir -p /tmp/odios
 tar xzf /tmp/odios.tar.gz -C /tmp/odios
 cd /tmp/odios
 
-PYTHONPATH="vendor" python3 vendor/bin/ansible-playbook \\
+PYTHONPATH="vendor" \\
+ANSIBLE_STRATEGY=mitogen_linear \\
+ANSIBLE_STRATEGY_PLUGINS="vendor/ansible_mitogen/plugins/strategy" \\
+python3 vendor/bin/ansible-playbook \\
     -i ansible/inventory/localhost.yml \\
     ansible/playbook.yml \\
     ${extra_vars_flags} \\

--- a/installer/ansible/playbook.yml
+++ b/installer/ansible/playbook.yml
@@ -2,6 +2,12 @@
 - name: Odio Streamer Installation
   hosts: localhost
 
+  # Skip the slow hardware fact probe (unused by odios); costly on armhf.
+  gather_subset:
+    - min
+    - network
+    - virtual
+
   vars_files:
     - group_vars/all.yml
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -303,6 +303,12 @@ download_archive() {
     else
         echo -e "${GREEN}✓ Archive extracted${NC}"
     fi
+
+    # Mitogen become_user does os.chdir into the playbook basedir; let
+    # target_user traverse the invoker's 0700 tempdir when they differ.
+    if [[ "${TARGET_USER}" != "$(id -un)" ]]; then
+        chmod o+x "${WORK_DIR}" "${WORK_DIR}/ansible"
+    fi
     echo ""
 }
 
@@ -364,6 +370,8 @@ EOF
 
     # shellcheck disable=SC2086
     PYTHONPATH="${WORK_DIR}/vendor" \
+    ANSIBLE_STRATEGY=mitogen_linear \
+    ANSIBLE_STRATEGY_PLUGINS="${WORK_DIR}/vendor/ansible_mitogen/plugins/strategy" \
         python3 "${WORK_DIR}/vendor/bin/ansible-playbook" \
         -i "${WORK_DIR}/ansible/inventory/localhost.yml" \
         "${WORK_DIR}/ansible/playbook.yml" \

--- a/licences/MITOGEN-LICENSE-BSD3
+++ b/licences/MITOGEN-LICENSE-BSD3
@@ -1,0 +1,26 @@
+Copyright 2021, the Mitogen authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -253,9 +253,19 @@ case "${1:-}" in
 esac
 
 install_ansible() {
-    echo "=== Installing ansible-core ==="
+    echo "=== Installing ansible-core + mitogen ==="
     docker exec "${CONTAINER_NAME}" \
-      pip3 install --break-system-packages --quiet "ansible-core==2.19.*"
+      pip3 install --break-system-packages --quiet "ansible-core==2.19.*" "mitogen==0.3.49"
+}
+
+# Enable Mitogen on the direct playbook path (test/rerun) via env vars, like
+# install.sh — resolves the strategy dir; emits nothing if mitogen is absent.
+mitogen_exec_env() {
+    local dir
+    dir=$(docker exec "${CONTAINER_NAME}" python3 -c \
+      'import os, ansible_mitogen; print(os.path.join(os.path.dirname(ansible_mitogen.__file__), "plugins", "strategy"))' \
+      2>/dev/null) || return 0
+    [[ -n "$dir" ]] && echo "-e ANSIBLE_STRATEGY=mitogen_linear -e ANSIBLE_STRATEGY_PLUGINS=${dir}"
 }
 
 # Under QEMU user-mode, sudo setuid is not honoured — run ansible as root.
@@ -277,7 +287,7 @@ case "${ACTION}" in
 
     echo "=== Running playbook ==="
     # shellcheck disable=SC2046
-    docker exec $(ansible_exec_user) "${CONTAINER_NAME}" \
+    docker exec $(ansible_exec_user) $(mitogen_exec_env) "${CONTAINER_NAME}" \
       ansible-playbook -v -i inventory/localhost.yml \
         /opt/odios/ansible/playbook.yml \
         $(ansible_extra_flags) \
@@ -295,7 +305,7 @@ case "${ACTION}" in
   rerun)
     echo "=== Re-running playbook ==="
     # shellcheck disable=SC2046
-    docker exec $(ansible_exec_user) "${CONTAINER_NAME}" \
+    docker exec $(ansible_exec_user) $(mitogen_exec_env) "${CONTAINER_NAME}" \
       ansible-playbook -i inventory/localhost.yml /opt/odios/ansible/playbook.yml \
         $(ansible_extra_flags) \
         -e "mpd_discplayer_gnu_email=test@example.com" \
@@ -304,7 +314,8 @@ case "${ACTION}" in
 
   rerun-as-other-user)
     echo "=== Re-running playbook as bob ==="
-    docker exec -u bob "${CONTAINER_NAME}" \
+    # shellcheck disable=SC2046
+    docker exec -u bob $(mitogen_exec_env) "${CONTAINER_NAME}" \
       ansible-playbook -i inventory/localhost.yml /opt/odios/ansible/playbook.yml \
         -e target_user=odio \
         -e install_mode=live \
@@ -347,7 +358,8 @@ case "${ACTION}" in
     setup_other_user bob
 
     echo "=== Running playbook as bob (target_user=odio, install_mode=live) ==="
-    docker exec -u bob "${CONTAINER_NAME}" \
+    # shellcheck disable=SC2046
+    docker exec -u bob $(mitogen_exec_env) "${CONTAINER_NAME}" \
       ansible-playbook -v -i inventory/localhost.yml \
         /opt/odios/ansible/playbook.yml \
         -e target_user=odio \


### PR DESCRIPTION
In-place upgrades take ~2h on armhf 700MHz: the dominant cost is Ansible's per-task overhead (a fresh python3 fork per module), not network or apt.

Vendor mitogen 0.3.49 (pure Python) alongside ansible-core and enable the mitogen_linear strategy, which reuses a live interpreter instead of forking per task. Wired via ANSIBLE_STRATEGY env vars at every invocation site — install.sh (upgrade), provision.sh (image build), and the direct test path in test.sh (so test-playbook-arm / armhf exercises it too). No role/task changes: readability and per-config correctness are preserved.

Note: ansible-core 2.19 deprecates third-party strategy plugins (future removal); mitigated by controlling the vendored ansible-core version.