### PR TITLE
fix: reload user manager after purging mpDris2

### DIFF
--- a/installer/ansible/roles/mpd/tasks/mpd2mpris.yml
+++ b/installer/ansible/roles/mpd/tasks/mpd2mpris.yml
@@ -32,6 +32,21 @@
         state: absent
         purge: true
       become: true
+      register: mpd_mpdris2_purge
+
+    # The purged unit keeps its BusName reserved until the manager re-reads unit
+    # files, which makes mpd2mpris.service refuse to load on the same bus name.
+    - name: Reload user manager after mpDris2 removal
+      ansible.builtin.systemd:
+        daemon_reload: true
+        scope: user
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ target_user_uid }}"
+      become: "{{ become_for_target_user }}"
+      become_user: "{{ target_user }}"
+      when:
+        - install_mode == "live"
+        - mpd_mpdris2_purge.changed
 
     - name: Remove legacy mpDris2 config dir
       ansible.builtin.file:

--- a/installer/ansible/roles/mpd/vars/main.yml
+++ b/installer/ansible/roles/mpd/vars/main.yml
@@ -1,4 +1,4 @@
 ---
-mpd_version: "2026.7.0rc1"
+mpd_version: "2026.7.0rc2"
 mpd_mpd2mpris_apt_version: "0.13.0"
 mpd_mympd_apt_version: "25.3.0"


### PR DESCRIPTION
Upgrading from a release predating the mpd2mpris rename purges the mpdris2 package, but the user manager keeps the removed unit loaded, so its BusName reservation on org.mpris.MediaPlayer2.mpd survives. Enabling mpd2mpris.service then fails with "Two services allocated for the same bus name".

Reload the user manager right after the purge, only when it actually removed something and only in live mode. Handlers cannot cover this: they flush at the end of the play, long after the enable task.

Reported on a Pi B+ upgrading 2026.6.0b2 to 2026.7.0rc1.


Claude-Session: https://claude.ai/code/session_01FEEqytQ7DM8cMuoZ8LHVHV